### PR TITLE
Update to target latest version of nuget package

### DIFF
--- a/samples/LayoutConsoleApp/LayoutConsoleApp.csproj
+++ b/samples/LayoutConsoleApp/LayoutConsoleApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ParagonApi" Version="7.1.0" />
+    <PackageReference Include="ParagonApi" Version="9.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Versions of the ParagonAPI Nuget package prior to 9.1.0 did not properly target MacOS/Linux platforms.